### PR TITLE
Fix missing/misplaced -lm during compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,7 @@ Makefile
 04.wo_Defects_Cpp/Makefile
 03.w_Defects_Cpp/Makefile
 ])
+AC_SEARCH_LIBS([pow], [m])
 
 # Checks for programs.
 AC_PROG_CXX


### PR DESCRIPTION
Previously, certain build steps would fail because gcc's `-lm` was included before the .o files, not after.
This addition causes the default Makefile to work correctly.